### PR TITLE
feat(unique): adds return_index to high performance paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 environment:
 
   matrix:
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/automated_test.py
+++ b/automated_test.py
@@ -383,65 +383,74 @@ def test_minmax():
 def test_unique():
   # array_unique
   labels = np.random.randint(0, 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique(labels, return_counts=True)
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   labels = np.random.randint(0, 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique_via_array(labels.flatten(), np.max(labels))
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True,return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique_via_array(labels.flatten(), np.max(labels), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   # array_unique + shift
   labels = np.random.randint(-500, 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique(labels, return_counts=True)
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   labels = np.random.randint(-500, 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten())
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   # array_unique + shift
   labels = np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique(labels, return_counts=True)
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   # array_unique + shift
   labels = np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten())
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
+  assert np.all(idx_np == idx_fr)
 
   # renumber + array_unique
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique(labels, return_counts=True)
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
+  assert np.all(idx_np == idx_fr)
 
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique_via_renumber(labels.flatten())
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique_via_renumber(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
+  assert np.all(idx_np == idx_fr)
 
   # sort
   labels = np.random.randint(-1000, 128**3, size=(100,100,100))
-  uniq_np, cts_np = np.unique(labels, return_counts=True)
-  uniq_fr, cts_fr = fastremap.unique(labels, return_counts=True)
+  uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
+  uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
+  assert np.all(idx_np == idx_fr)
 
   labels = np.random.randint(-1000, 128**3, size=(100,100,100))
   uniq_np, cts_np = np.unique(labels, return_counts=True)

--- a/automated_test.py
+++ b/automated_test.py
@@ -380,83 +380,89 @@ def test_minmax():
   assert minval == np.min(volume)
   assert maxval == np.max(volume)
 
-def test_unique():
+@pytest.mark.parametrize("order", [ "C", "F" ])
+def test_unique(order):
+  def reorder(arr):
+    if order == "F":
+      return np.asfortranarray(arr)
+    return np.ascontiguousarray(arr)
+
   # array_unique
-  labels = np.random.randint(0, 500, size=(128,128,128))
+  labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
-  labels = np.random.randint(0, 500, size=(128,128,128))
+  labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True,return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique_via_array(labels.flatten(), np.max(labels), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   # array_unique + shift
-  labels = np.random.randint(-500, 500, size=(128,128,128))
+  labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
-  labels = np.random.randint(-500, 500, size=(128,128,128))
+  labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   # array_unique + shift
-  labels = np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128))
+  labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   # array_unique + shift
-  labels = np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128))
+  labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique_via_shifted_array(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   # renumber + array_unique
-  labels = np.random.randint(0, 1, size=(128,128,128))
+  labels = reorder(np.random.randint(0, 1, size=(128,128,128)))
   labels[0,0,0] = 128**3 + 10
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
-  labels = np.random.randint(0, 1, size=(128,128,128))
+  labels = reorder(np.random.randint(0, 1, size=(128,128,128)))
   labels[0,0,0] = 128**3 + 10
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique_via_renumber(labels.flatten(), return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   # sort
-  labels = np.random.randint(-1000, 128**3, size=(100,100,100))
+  labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
   uniq_np, idx_np, cts_np = np.unique(labels, return_counts=True, return_index=True)
   uniq_fr, idx_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(cts_np == cts_fr)  
-  assert np.all(idx_np == idx_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
-  labels = np.random.randint(-1000, 128**3, size=(100,100,100))
+  labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
   uniq_np, cts_np = np.unique(labels, return_counts=True)
   uniq_fr, cts_fr = fastremap.unique_via_sort(labels.flatten())
   assert np.all(uniq_np == uniq_fr)
-  assert np.all(cts_np == cts_fr)  
+  assert np.all(cts_np == cts_fr)
 
 def test_renumber_remap():
   labels = np.random.randint(-500, 500, size=(128,128,128)).astype(np.int64)

--- a/fastremap.pyx
+++ b/fastremap.pyx
@@ -719,7 +719,7 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
 
   # These flags are currently unsupported so call uncle and
   # use the standard implementation instead.
-  if return_index or return_inverse or (axis is not None):
+  if return_inverse or (axis is not None):
     return np.unique(
       labels, 
       return_index=return_index, 
@@ -740,36 +740,45 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
   if voxels == 0:
     uniq = np.array([], dtype=labels.dtype)
     counts = np.array([], dtype=np.uint32)
+    index = np.array([], dtype=np.uint64)
   elif min_label >= 0 and max_label < <int64_t>voxels:
-    uniq, counts = unique_via_array(labels, max_label)
+    uniq, counts, index = unique_via_array(labels, max_label, return_index=return_index)
   elif (max_label - min_label) <= <int64_t>voxels:
-    uniq, counts = unique_via_shifted_array(labels, min_label, max_label)
+    uniq, counts, index = unique_via_shifted_array(labels, min_label, max_label, return_index=return_index)
   elif float(pixel_pairs(labels)) / float(voxels) > 0.66:
-    uniq, counts = unique_via_renumber(labels)
+    uniq, counts, index = unique_via_renumber(labels, return_index=return_index)
+  elif return_index:
+    return np.unique(labels, return_index=return_index, return_counts=return_counts)
   else:
     uniq, counts = unique_via_sort(labels)
 
+  results = [ uniq ]
+  if return_index:
+    results.append(index)
   if return_counts:
-    return uniq, counts
+    results.append(counts)
+
+  if len(results) > 1:
+    return tuple(results)
   return uniq
 
-def unique_via_shifted_array(labels, min_label=None, max_label=None):
+def unique_via_shifted_array(labels, min_label=None, max_label=None, return_index=False):
   if min_label is None or max_label is None:
     min_label, max_label = minmax(labels)
 
   labels -= min_label
-  uniq, counts = unique_via_array(labels, max_label - min_label + 1)
+  uniq, counts, idx = unique_via_array(labels, max_label - min_label + 1, return_index)
   labels += min_label
   uniq += min_label
-  return uniq, counts
+  return uniq, counts, idx
 
-def unique_via_renumber(labels):
+def unique_via_renumber(labels, return_index=False):
   dtype = labels.dtype
   labels, remap = renumber(labels)
   remap = { v:k for k,v in remap.items() }
-  uniq, counts = unique_via_array(labels, max(remap.keys()))
+  uniq, counts, idx = unique_via_array(labels, max(remap.keys()), return_index)
   uniq = np.array([ remap[segid] for segid in uniq ], dtype=dtype)
-  return uniq, counts
+  return uniq, counts, idx
 
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
@@ -807,7 +816,7 @@ def unique_via_sort(cnp.ndarray[ALLINT, ndim=1] labels):
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
 @cython.nonecheck(False)
-def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label):
+def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label, return_index=False):
   """
   unique(cnp.ndarray[ALLINT, ndim=1] labels, return_counts=False)
 
@@ -818,11 +827,23 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label):
   cdef cnp.ndarray[uint32_t, ndim=1] counts = np.zeros( 
     (max_label+1,), dtype=np.uint32
   )
+  cdef cnp.ndarray[uint64_t, ndim=1] index
+  
+  cdef size_t sentinel = np.iinfo(np.uint64).max
+  if return_index:
+    index = np.zeros( 
+      (max_label+1,), dtype=np.uint64
+    ) + sentinel
 
   cdef size_t voxels = labels.shape[0]
   cdef size_t i = 0
   for i in range(voxels):
     counts[labels[i]] += 1
+
+  if return_index:
+    for i in range(voxels):
+      if index[labels[i]] == sentinel:
+        index[labels[i]] = i
 
   cdef size_t real_size = 0
   for i in range(max_label + 1):
@@ -835,6 +856,7 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label):
   cdef cnp.ndarray[uint32_t, ndim=1] cts = np.zeros( 
     (real_size,), dtype=np.uint32
   )
+  cdef cnp.ndarray[uint64_t, ndim=1] idx
 
   cdef size_t j = 0
   for i in range(max_label + 1):
@@ -843,8 +865,19 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label):
       cts[j] = counts[i]
       j += 1
 
-  return segids, cts
-  
+  if return_index:
+    idx = np.zeros( (real_size,), dtype=np.uint64)
+    j = 0
+    for i in range(max_label + 1):
+      if counts[i] > 0:
+        idx[j] = index[i]
+        j += 1   
+
+  if return_index:
+    return segids, cts, idx
+  else:
+    return segids, cts, None
+
 def transpose(arr):
   """
   transpose(arr)

--- a/fastremap.pyx
+++ b/fastremap.pyx
@@ -17,7 +17,8 @@ Date: August 2018 - January 2020
 cimport cython
 from libc.stdint cimport (  
   uint8_t, uint16_t, uint32_t, uint64_t,
-  int8_t, int16_t, int32_t, int64_t
+  int8_t, int16_t, int32_t, int64_t,
+  uintptr_t
 )
 from libcpp.unordered_map cimport unordered_map
 
@@ -840,12 +841,12 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label, retur
   cdef cnp.ndarray[uint32_t, ndim=1] counts = np.zeros( 
     (max_label+1,), dtype=np.uint32
   )
-  cdef cnp.ndarray[uint64_t, ndim=1] index
+  cdef cnp.ndarray[uintptr_t, ndim=1] index
   
-  cdef size_t sentinel = np.iinfo(np.uint64).max
+  cdef uintptr_t sentinel = np.iinfo(np.uintp).max
   if return_index:
     index = np.zeros( 
-      (max_label+1,), dtype=np.uint64
+      (max_label+1,), dtype=np.uintp
     ) + sentinel
 
   cdef size_t voxels = labels.shape[0]
@@ -869,7 +870,7 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label, retur
   cdef cnp.ndarray[uint32_t, ndim=1] cts = np.zeros( 
     (real_size,), dtype=np.uint32
   )
-  cdef cnp.ndarray[uint64_t, ndim=1] idx
+  cdef cnp.ndarray[uintptr_t, ndim=1] idx
 
   cdef size_t j = 0
   for i in range(max_label + 1):
@@ -879,7 +880,7 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label, retur
       j += 1
 
   if return_index:
-    idx = np.zeros( (real_size,), dtype=np.uint64)
+    idx = np.zeros( (real_size,), dtype=np.uintp)
     j = 0
     for i in range(max_label + 1):
       if counts[i] > 0:

--- a/fastremap.pyx
+++ b/fastremap.pyx
@@ -742,11 +742,11 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
     counts = np.array([], dtype=np.uint32)
     index = np.array([], dtype=np.uint64)
   elif min_label >= 0 and max_label < <int64_t>voxels:
-    uniq, counts, index = unique_via_array(labels, max_label, return_index=return_index)
+    uniq, index, counts = unique_via_array(labels, max_label, return_index=return_index)
   elif (max_label - min_label) <= <int64_t>voxels:
-    uniq, counts, index = unique_via_shifted_array(labels, min_label, max_label, return_index=return_index)
+    uniq, index, counts = unique_via_shifted_array(labels, min_label, max_label, return_index=return_index)
   elif float(pixel_pairs(labels)) / float(voxels) > 0.66:
-    uniq, counts, index = unique_via_renumber(labels, return_index=return_index)
+    uniq, index, counts = unique_via_renumber(labels, return_index=return_index)
   elif return_index:
     return np.unique(labels, return_index=return_index, return_counts=return_counts)
   else:
@@ -767,18 +767,18 @@ def unique_via_shifted_array(labels, min_label=None, max_label=None, return_inde
     min_label, max_label = minmax(labels)
 
   labels -= min_label
-  uniq, counts, idx = unique_via_array(labels, max_label - min_label + 1, return_index)
+  uniq, idx, counts = unique_via_array(labels, max_label - min_label + 1, return_index)
   labels += min_label
   uniq += min_label
-  return uniq, counts, idx
+  return uniq, idx, counts
 
 def unique_via_renumber(labels, return_index=False):
   dtype = labels.dtype
   labels, remap = renumber(labels)
   remap = { v:k for k,v in remap.items() }
-  uniq, counts, idx = unique_via_array(labels, max(remap.keys()), return_index)
+  uniq, idx, counts = unique_via_array(labels, max(remap.keys()), return_index)
   uniq = np.array([ remap[segid] for segid in uniq ], dtype=dtype)
-  return uniq, counts, idx
+  return uniq, idx, counts
 
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
@@ -874,9 +874,9 @@ def unique_via_array(cnp.ndarray[ALLINT, ndim=1] labels, size_t max_label, retur
         j += 1   
 
   if return_index:
-    return segids, cts, idx
+    return segids, idx, cts
   else:
-    return segids, cts, None
+    return segids, None, cts
 
 def transpose(arr):
   """


### PR DESCRIPTION
Note that right now the results are different from np.unique for
fortran arrays as np.unique always returns C order indexes.