### PR TITLE
feat: add equal_nan, sorted, and fast u64 edge list sort

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest -r requirements.txt -r requirements_dev.txt setuptools wheel
+          python -m pip install "numpy>=2.0"
 
       - name: Compile
         run: python setup.py develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest -r requirements.txt -r requirements_dev.txt setuptools wheel
-          python -m pip install "numpy>=2.3"
 
       - name: Compile
         run: python setup.py develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest -r requirements.txt -r requirements_dev.txt setuptools wheel
-          python -m pip install "numpy>=2.0"
+          python -m pip install "numpy>=2.3"
 
       - name: Compile
         run: python setup.py develop

--- a/automated_test.py
+++ b/automated_test.py
@@ -455,7 +455,7 @@ def test_unique(read_only, order, equal_nan, sorted):
   assert len(fastremap.unique(np.array([], dtype=np.uint8))) == 0
 
   labels = reorder(np.array([777]))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr,  = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -464,7 +464,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # array_unique
   labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -472,7 +472,7 @@ def test_unique(read_only, order, equal_nan, sorted):
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_array(labels.flatten(), np.max(labels), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -481,7 +481,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # array_unique + shift
   labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -489,7 +489,7 @@ def test_unique(read_only, order, equal_nan, sorted):
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_shifted_array(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -498,7 +498,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # array_unique + shift
   labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -507,7 +507,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # array_unique + shift
   labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_shifted_array(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -518,7 +518,7 @@ def test_unique(read_only, order, equal_nan, sorted):
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
   labels = reorder(labels)
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -528,7 +528,7 @@ def test_unique(read_only, order, equal_nan, sorted):
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
   labels = reorder(labels)
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_renumber(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -537,7 +537,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # sort
   labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -556,14 +556,14 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # sort no counts
   labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
-  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr = fastremap.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   floats = np.random.uniform(-1e6, 1e6, size=(100,100,100))
-  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan)
   uniq_fr, idx_fr, inv_fr = fastremap.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
@@ -571,7 +571,7 @@ def test_unique(read_only, order, equal_nan, sorted):
 
   # Test edge list sort
   pairs = np.random.randint(0, int(1e10), size=[100_000, 2], dtype=np.uint64)
-  uniq_np = np.unique(pairs, axis=0, sorted=sorted)
+  uniq_np = np.unique(pairs, axis=0)
   uniq_fr = fastremap.unique(pairs, axis=0, sorted=sorted)
 
   np_set = set(map(tuple, uniq_np))

--- a/automated_test.py
+++ b/automated_test.py
@@ -442,7 +442,9 @@ def test_unique_axis_0_random():
 
 @pytest.mark.parametrize("order", [ "C", "F" ])
 @pytest.mark.parametrize("read_only", [ False, True ])
-def test_unique(read_only, order):
+@pytest.mark.parametrize("equal_nan", [ False, True ])
+@pytest.mark.parametrize("sorted", [ False, True ])
+def test_unique(read_only, order, equal_nan, sorted):
   def reorder(arr):
     if order == "F":
       arr2 = np.asfortranarray(arr)
@@ -453,8 +455,8 @@ def test_unique(read_only, order):
   assert len(fastremap.unique(np.array([], dtype=np.uint8))) == 0
 
   labels = reorder(np.array([777]))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr,  = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr,  = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)
@@ -462,15 +464,15 @@ def test_unique(read_only, order):
 
   # array_unique
   labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   labels = reorder(np.random.randint(0, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_array(labels.flatten(), np.max(labels), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -479,15 +481,15 @@ def test_unique(read_only, order):
 
   # array_unique + shift
   labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
   labels = reorder(np.random.randint(-500, 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_shifted_array(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -496,8 +498,8 @@ def test_unique(read_only, order):
 
   # array_unique + shift
   labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)
@@ -505,7 +507,7 @@ def test_unique(read_only, order):
 
   # array_unique + shift
   labels = reorder(np.random.randint(128**3 - 500, 128**3 + 500, size=(128,128,128)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_shifted_array(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -516,8 +518,8 @@ def test_unique(read_only, order):
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
   labels = reorder(labels)
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)  
@@ -526,7 +528,7 @@ def test_unique(read_only, order):
   labels = np.random.randint(0, 1, size=(128,128,128))
   labels[0,0,0] = 128**3 + 10
   labels = reorder(labels)
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   uniq_fr, idx_fr, cts_fr, inv_fr = fastremap.fastremap._unique_via_renumber(labels.flatten(), return_index=True, return_inverse=True)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np.flatten() == inv_fr)
@@ -535,8 +537,8 @@ def test_unique(read_only, order):
 
   # sort
   labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
-  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np, cts_np = np.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr, cts_fr = fastremap.unique(labels, return_counts=True, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(cts_np == cts_fr)  
@@ -554,8 +556,8 @@ def test_unique(read_only, order):
 
   # sort no counts
   labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
-  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True)
-  uniq_fr, idx_fr, inv_fr = fastremap.unique(labels, return_counts=False, return_index=True, return_inverse=True)
+  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
+  uniq_fr, idx_fr, inv_fr = fastremap.unique(labels, return_counts=False, return_index=True, return_inverse=True, equal_nan=equal_nan, sorted=sorted)
   assert np.all(uniq_np == uniq_fr)
   assert np.all(inv_np == inv_fr)
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])

--- a/automated_test.py
+++ b/automated_test.py
@@ -569,6 +569,20 @@ def test_unique(read_only, order, equal_nan, sorted):
   assert np.all(inv_np == inv_fr)
   assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
+  # Test edge list sort
+  pairs = np.random.randint(0, int(1e10), size=[100_000, 2], dtype=np.uint64)
+  uniq_np = np.unique(pairs, axis=0, sorted=sorted)
+  uniq_fr = fastremap.unique(pairs, axis=0, sorted=sorted)
+
+  np_set = set(map(tuple, uniq_np))
+  fr_set = set(map(tuple, uniq_fr))
+  only_in_numpy = np.array(list(np_set - fr_set))
+  only_in_fastremap = np.array(list(fr_set - np_set))
+
+  assert 0 < uniq_np.size <= pairs.size
+  assert only_in_numpy.size == 0
+  assert only_in_fastremap.size == 0
+
 def test_renumber_remap():
   labels = np.random.randint(-500, 500, size=(128,128,128)).astype(np.int64)
   new_labels, remap = fastremap.renumber(labels, in_place=False)

--- a/automated_test.py
+++ b/automated_test.py
@@ -552,6 +552,13 @@ def test_unique(read_only, order):
   uniq = fastremap.unique(labels)
   assert np.all(uniq == np.array([1,2,3,4]))
 
+  # sort no counts
+  labels = reorder(np.random.randint(-1000, 128**3, size=(100,100,100)))
+  uniq_np, idx_np, inv_np = np.unique(labels, return_counts=False, return_index=True, return_inverse=True)
+  uniq_fr, idx_fr, inv_fr = fastremap.unique(labels, return_counts=False, return_index=True, return_inverse=True)
+  assert np.all(uniq_np == uniq_fr)
+  assert np.all(inv_np == inv_fr)
+  assert np.all(labels.flatten()[idx_np] == labels.flatten()[idx_fr])
 
 def test_renumber_remap():
   labels = np.random.randint(-500, 500, size=(128,128,128)).astype(np.int64)

--- a/fastremap/fastremap.pyi
+++ b/fastremap/fastremap.pyi
@@ -10,6 +10,9 @@ def unique(
     return_inverse: Literal[False] = False,
     return_counts: Literal[False] = False,
     axis: Union[int, None] = None,
+    *,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> NDArray[Any]: ...
 @overload
 def unique(
@@ -18,14 +21,9 @@ def unique(
     return_inverse: Literal[False] = False,
     return_counts: Literal[False] = False,
     axis: Union[int, None] = None,
-) -> tuple[NDArray[Any], NDArray[Any]]: ...
-@overload
-def unique(
-    labels: ArrayLike,
-    return_index: Literal[False],
-    return_inverse: Literal[True],
-    return_counts: Literal[False] = False,
-    axis: Union[int, None] = None,
+    *,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
@@ -35,14 +33,8 @@ def unique(
     return_inverse: Literal[True],
     return_counts: Literal[False] = False,
     axis: Union[int, None] = None,
-) -> tuple[NDArray[Any], NDArray[Any]]: ...
-@overload
-def unique(
-    labels: ArrayLike,
-    return_index: Literal[False],
-    return_inverse: Literal[False],
-    return_counts: Literal[True],
-    axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
@@ -52,22 +44,19 @@ def unique(
     *,
     return_counts: Literal[True],
     axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
     labels: ArrayLike,
     return_index: Literal[True],
+    *,
     return_inverse: Literal[True],
     return_counts: Literal[False] = False,
     axis: Union[int, None] = None,
-) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]: ...
-@overload
-def unique(
-    labels: ArrayLike,
-    return_index: Literal[True],
-    return_inverse: Literal[False],
-    return_counts: Literal[True],
-    axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
@@ -77,14 +66,8 @@ def unique(
     *,
     return_counts: Literal[True],
     axis: Union[int, None] = None,
-) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]: ...
-@overload
-def unique(
-    labels: ArrayLike,
-    return_index: Literal[False],
-    return_inverse: Literal[True],
-    return_counts: Literal[True],
-    axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
@@ -94,14 +77,19 @@ def unique(
     return_inverse: Literal[True],
     return_counts: Literal[True],
     axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]: ...
 @overload
 def unique(
     labels: ArrayLike,
     return_index: Literal[True],
+    *,
     return_inverse: Literal[True],
     return_counts: Literal[True],
     axis: Union[int, None] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any], NDArray[Any]]: ...
 def unique(  # type: ignore[misc]
     labels: ArrayLike,
@@ -109,6 +97,9 @@ def unique(  # type: ignore[misc]
     return_inverse: bool = False,
     return_counts: bool = False,
     axis: Union[int, None] = None,
+    *,
+    equal_nan: bool = True,
+    sorted: bool = True,
 ) -> Union[
     NDArray[Any],
     tuple[NDArray[Any], NDArray[Any]],
@@ -128,6 +119,9 @@ def unique(  # type: ignore[misc]
             array.
         axis: If specified and not None, compute the unique values along this
             axis.
+        equal_nan: If True, collapses multiple NaN values in the return array
+            into one.
+        sorted: If True, the unique elements are sorted.
 
     Returns:
         Either an array of the sorted values or a tuple containing the following

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -1080,10 +1080,10 @@ def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
     del lo_packed
     i = j
 
-    mask = np.ones(n, dtype=bool)
-    mask[1:] = np.any(labels[1:] != labels[:-1], axis=1)
+  mask = np.ones(n, dtype=bool)
+  mask[1:] = np.any(labels[1:] != labels[:-1], axis=1)
 
-    return labels[mask]
+  return labels[mask]
 
 def _unique_via_shifted_array(labels, min_label=None, max_label=None, return_index=False, return_inverse=False):
   if min_label is None or max_label is None:

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -1039,17 +1039,22 @@ def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
   # of the top bits?
   
   hi = labels >> 32
-  packed = (hi[:, 0] << 32) | hi[:, 1]
+  cdef cnp.ndarray[uint64_t] hi_packed = (hi[:, 0] << 32) | hi[:, 1]
   del hi
 
   # NOTE: kind='stable' is required to replicate numpy semantics
   # but is significantly slower.
-  order = np.argsort(packed) 
+  order = np.argsort(hi_packed) 
   labels = labels[order]
-  packed = packed[order]
+  hi_packed = hi_packed[order]
   del order
 
-  cdef uint64_t n = len(packed)
+  # must do lo after hi_packed is rearranged
+  lo = labels & 0xffffffff
+  cdef cnp.ndarray[uint64_t] lo_packed = (lo[:, 0] << 32) | lo[:, 1]
+  del lo
+
+  cdef uint64_t n = len(hi_packed)
   cdef uint64_t i = 0
   cdef uint64_t j = 0
   cdef uint64_t run_len = 0
@@ -1060,16 +1065,19 @@ def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
   while i < n:
     j = i + 1
 
-    while j < n and packed[j] == packed[i]:
+    while j < n and hi_packed[j] == hi_packed[i]:
       j += 1
 
     run_len = j - i
 
     if run_len > 1:
-      sub = labels[i:j]
-      idx = np.lexsort((sub[:, 1], sub[:, 0]))
-      labels[i:j] = sub[idx]
+      sub = lo_packed[i:j]
+      idx = np.argsort(sub)
+      labels[i:j] = labels[i:j][idx]
+      del sub
 
+    del hi_packed
+    del lo_packed
     i = j
 
     mask = np.ones(n, dtype=bool)

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -25,11 +25,14 @@ cimport fastremap
 
 from collections import defaultdict
 from functools import reduce
+from packaging import version
 import operator
 
 import numpy as np
 cimport numpy as cnp
 cnp.import_array()
+
+from numpy.typing import ArrayLike, NDArray
 
 from libcpp.vector cimport vector
 from libcpp.algorithm cimport sort as std_sort, unique as std_unique
@@ -67,6 +70,8 @@ cdef extern from "ipt.hpp" namespace "pyipt":
   cdef void _ipt4d[T](
     T* arr, size_t sx, size_t sy, size_t sz, size_t sw
   )
+
+NUMPY_SUPPORTS_SORTED = version.parse(np.__version__) >= version.parse("2.3.0")
 
 def minmax(arr):
   """
@@ -888,7 +893,16 @@ def _pixel_pairs(cnp.ndarray[ALLINT, ndim=1] labels):
   return pairs
 
 @cython.binding(True)
-def unique(labels, return_index=False, return_inverse=False, return_counts=False, axis=None):
+def unique(
+  labels:ArrayLike,
+  return_index:bool = False,
+  return_inverse:bool = False,
+  return_counts:bool = False,
+  axis:Optional[int] = None,
+  *,
+  equal_nan:bool = True,
+  sorted:bool = True,
+):
   """
   Compute the sorted set of unique labels in the input array.
 
@@ -914,6 +928,11 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
     unique_counts ndarray, optional
         The number of times each of the unique values comes up in the original array. 
         Only provided if return_counts is True.
+
+    equal_nan: If True, collapses multiple NaN values in the return array
+        into one.
+
+    sorted: If True, the unique elements are sorted.
   """
   if not isinstance(labels, np.ndarray):
     labels = np.array(labels)
@@ -926,20 +945,31 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
       and (
         labels.ndim == 2 
         and labels.shape[1] == 2
-        # and np.dtype(labels.dtype).itemsize < 8 
+        and not (sorted and np.dtype(labels.dtype).itemsize >= 8)
         and np.issubdtype(labels.dtype, np.integer)
       )
       and not (return_index or return_inverse or return_counts)
       and labels.flags.c_contiguous
     ):
       return _two_axis_unique(labels)
+    elif NUMPY_SUPPORTS_SORTED:
+      return np.unique(
+        labels, 
+        return_index=return_index, 
+        return_inverse=return_inverse, 
+        return_counts=return_counts, 
+        axis=axis,
+        equal_nan=equal_nan,
+        sorted=sorted,
+      )
     else:
       return np.unique(
         labels, 
         return_index=return_index, 
         return_inverse=return_inverse, 
         return_counts=return_counts, 
-        axis=axis
+        axis=axis,
+        equal_nan=equal_nan,
       )
 
   cdef size_t voxels = labels.size
@@ -1004,7 +1034,7 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
     return tuple(results)
   return uniq
 
-def _two_axis_unique(labels):
+def _two_axis_unique(labels:NDArray) -> NDArray:
   """
   Faster replacement for np.unique(labels, axis=0)
   when ndim = 2 and the dtype can be widened.
@@ -1042,9 +1072,7 @@ def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
   cdef cnp.ndarray[uint64_t] hi_packed = (hi[:, 0] << 32) | hi[:, 1]
   del hi
 
-  # NOTE: kind='stable' is required to replicate numpy semantics
-  # but is significantly slower.
-  order = np.argsort(hi_packed) 
+  order = np.argsort(hi_packed)
   labels = labels[order]
   hi_packed = hi_packed[order]
   del order

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -71,7 +71,7 @@ cdef extern from "ipt.hpp" namespace "pyipt":
     T* arr, size_t sx, size_t sy, size_t sz, size_t sw
   )
 
-NUMPY_SUPPORTS_SORTED = version.parse(np.__version__) >= version.parse("2.3.0")
+_NUMPY_SUPPORTS_SORTED = version.parse(np.__version__) >= version.parse("2.3.0")
 
 def minmax(arr):
   """
@@ -952,7 +952,7 @@ def unique(
       and labels.flags.c_contiguous
     ):
       return _two_axis_unique(labels)
-    elif NUMPY_SUPPORTS_SORTED:
+    elif _NUMPY_SUPPORTS_SORTED:
       return np.unique(
         labels, 
         return_index=return_index, 

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -32,6 +32,7 @@ cimport numpy as cnp
 cnp.import_array()
 
 from libcpp.vector cimport vector
+from libcpp.algorithm cimport sort as std_sort, unique as std_unique
 
 ctypedef fused UINT:
   uint8_t
@@ -980,6 +981,11 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
     uniq, index, counts, inverse = _unique_via_renumber(labels, return_index=return_index, return_inverse=return_inverse)
   elif return_index or return_inverse:
     return np.unique(labels_orig, return_index=return_index, return_counts=return_counts, return_inverse=return_inverse)
+  elif not return_counts:
+    uniq = _unique_via_sort_no_counts(labels)
+    index = None
+    inverse = None
+    counts = None
   else:
     uniq, counts = _unique_via_sort(labels)
     index = None
@@ -1054,6 +1060,25 @@ def _unique_via_renumber(labels, return_index=False, return_inverse=False):
     inverse = inv_map[inverse]
 
   return uniq, idx, counts, inverse
+
+@cython.boundscheck(False)
+@cython.wraparound(False)  # turn off negative index wrapping for entire function
+@cython.nonecheck(False)
+def _unique_via_sort_no_counts(cnp.ndarray[ALLINT, ndim=1] labels):
+  """Faster unique using std::sort and std::unique when counts are not needed."""
+  labels = np.copy(labels)
+  cdef size_t voxels = labels.size
+
+  if voxels == 0:
+    return np.array([], dtype=labels.dtype)
+
+  cdef ALLINT* end
+  with nogil:
+    std_sort(&labels[0], &labels[0] + voxels)
+    end = std_unique(&labels[0], &labels[0] + voxels)
+  cdef size_t num_unique = end - &labels[0]
+  labels.resize((num_unique,), refcheck=False)
+  return labels
 
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -926,7 +926,7 @@ def unique(labels, return_index=False, return_inverse=False, return_counts=False
       and (
         labels.ndim == 2 
         and labels.shape[1] == 2
-        and np.dtype(labels.dtype).itemsize < 8 
+        # and np.dtype(labels.dtype).itemsize < 8 
         and np.issubdtype(labels.dtype, np.integer)
       )
       and not (return_index or return_inverse or return_counts)
@@ -1014,12 +1014,68 @@ def _two_axis_unique(labels):
   dtype = labels.dtype
   wide_dtype = widen_dtype(dtype)
 
+  if np.dtype(dtype).itemsize == 8:
+    return _two_axis_unique_u64(labels.view(np.uint64))
+
   labels = labels[:, [1,0]].reshape(-1, order="C")
   labels = labels.view(wide_dtype)
   labels = unique(labels)
   N = len(labels)
   labels = labels.view(dtype).reshape((N, 2), order="C")
   return labels[:,[1,0]]
+
+def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
+  
+  # Sorting based on packed (u32,u32)->u64 is extremely fast
+  # but we can't do that for (u64,u64) because hardware doesn't
+  # support u128. So the alternative strategy here is to create
+  # a partially sorted order using the top bits of the u64 and
+  # then apply local refinements to the sorting order. In many
+  # cases, this is substantially faster.
+
+  # For situations where the top bits tend to cluster, perhaps
+  # it would make sense to adjust `labels >> 32` and make that
+  # integer variable in order to select a more variable section
+  # of the top bits?
+  
+  hi = labels >> 32
+  packed = (hi[:, 0] << 32) | hi[:, 1]
+  del hi
+
+  # NOTE: kind='stable' is required to replicate numpy semantics
+  # but is significantly slower.
+  order = np.argsort(packed) 
+  labels = labels[order]
+  packed = packed[order]
+  del order
+
+  cdef uint64_t n = len(packed)
+  cdef uint64_t i = 0
+  cdef uint64_t j = 0
+  cdef uint64_t run_len = 0
+
+  if n == 0:
+    return labels
+
+  while i < n:
+    j = i + 1
+
+    while j < n and packed[j] == packed[i]:
+      j += 1
+
+    run_len = j - i
+
+    if run_len > 1:
+      sub = labels[i:j]
+      idx = np.lexsort((sub[:, 1], sub[:, 0]))
+      labels[i:j] = sub[idx]
+
+    i = j
+
+    mask = np.ones(n, dtype=bool)
+    mask[1:] = np.any(labels[1:] != labels[:-1], axis=1)
+
+    return labels[mask]
 
 def _unique_via_shifted_array(labels, min_label=None, max_label=None, return_index=False, return_inverse=False):
   if min_label is None or max_label is None:

--- a/fastremap/fastremap.pyx
+++ b/fastremap/fastremap.pyx
@@ -1076,10 +1076,11 @@ def _two_axis_unique_u64(cnp.ndarray[uint64_t, ndim=2] labels):
       labels[i:j] = labels[i:j][idx]
       del sub
 
-    del hi_packed
-    del lo_packed
     i = j
 
+  del hi_packed
+  del lo_packed
+  
   mask = np.ones(n, dtype=bool)
   mask[1:] = np.any(labels[1:] != labels[:-1], axis=1)
 


### PR DESCRIPTION
New edge list sort for u64, (N,2) when `sorted=False`.

```python
uniq = fastremap.unique(edge_list, sorted=False)
```